### PR TITLE
add styles for responsive height of rows

### DIFF
--- a/src/components/base/TableRowCar/TableRowCar.module.scss
+++ b/src/components/base/TableRowCar/TableRowCar.module.scss
@@ -11,6 +11,7 @@
     minmax(100px, 105px) !important;
 
   gap: 20px !important;
+  height: max(calc(100% / 8), 73px);
 
   &IconLabel {
     font-size: inherit;

--- a/src/components/base/TableRowFlight/TableRowFlight.module.scss
+++ b/src/components/base/TableRowFlight/TableRowFlight.module.scss
@@ -7,6 +7,8 @@
     repeat(2, minmax(100px, 130px))
     minmax(100px, max-content) !important;
 
+    height: max(calc(100% / 10), 59px);
+
   & > td {
     font-size: 14px;
     line-height: 1.375;

--- a/src/components/modules/TableScore/TableScore.module.scss
+++ b/src/components/modules/TableScore/TableScore.module.scss
@@ -86,6 +86,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  flex: 1 1 auto;
 }
 
 .tableHead {


### PR DESCRIPTION
As per advice of Vitalii

height: max(calc(100% / 8), 73px) for car row
height: max(calc(100% / 10), 59px) for plane row 